### PR TITLE
[TASK] Prepare for TYPO3 v13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
 	},
 	"require": {
 		"haydenpierce/class-finder": "^0.4.3",
-		"t3docs/blog-example": "^12.0",
+		"t3docs/blog-example": "^13.0",
 		"t3docs/codesnippet": "@dev",
-		"t3docs/examples": "dev-main",
+		"t3docs/examples": "^13.0",
 		"t3docs/site-package": "dev-main",
 		"ttn/tea": "^3.0",
 		"typo3-documentation-team/speeddemo": "^11.4",
@@ -53,5 +53,7 @@
 		"typo3/cms-tstemplate": "dev-main as 12.4",
 		"typo3/cms-viewpage": "dev-main as 12.4",
 		"typo3/cms-workspaces": "dev-main as 12.4"
-	}
+	},
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
This way, the dependencies can be installed again. Previously, errors occured.

Releases: main