### PR TITLE
[TASK] Update to PHP 8.2

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: t3docs-codesnippets
 type: typo3
 docroot: public
-php_version: "8.1"
+php_version: "8.2"
 webserver_type: nginx-fpm
 router_http_port: "80"
 router_https_port: "443"
@@ -82,7 +82,7 @@ web_environment: []
 # Please take care with this because it can cause great confusion.
 
 # upload_dir: custom/upload/dir
-# would set the destination path for ddev import-files to <docroot>/custom/upload/dir 
+# would set the destination path for ddev import-files to <docroot>/custom/upload/dir
 
 # working_dir:
 #   web: /var/www/html


### PR DESCRIPTION
TYPO3 v13 has PHP 8.2 at minimum requirement.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/781